### PR TITLE
Fix duplication issue

### DIFF
--- a/lib/ToggleSwitch.js
+++ b/lib/ToggleSwitch.js
@@ -1,11 +1,12 @@
 /**
  * Created by SagarKhatri on 18-Aug-15.
+ * Updated by AndreF010203 on 6-Aug-19
  */
 (function ($) {
-
     $.fn.toggleSwitch = function () {
         var id = this.attr("id"),
             switchDivId = id + "-switch";
+        if($("div#"+switchDivId).length>0) return;
         $("<div/>", {class: "onoffswitch", id: switchDivId}).insertAfter(this);
         $("div#" + switchDivId).append(this.clone().addClass('onoffswitch-checkbox'));
         $("<label/>", {


### PR DESCRIPTION
Avoid to create a new switch element when one already exists in the page